### PR TITLE
Add time-based slides

### DIFF
--- a/app/controllers/spree/admin/slides_controller.rb
+++ b/app/controllers/spree/admin/slides_controller.rb
@@ -18,7 +18,16 @@ module Spree
       end
 
       def slide_params
-        params.require(:slide).permit(:name, :body, :link_url, :published, :image, :position, :product_id)
+        params.require(:slide)
+          .permit(:name,
+                  :body,
+                  :link_url,
+                  :published,
+                  :image,
+                  :position,
+                  :product_id,
+                  :starts_at,
+                  :ends_at)
       end
     end
   end

--- a/app/models/spree/slide.rb
+++ b/app/models/spree/slide.rb
@@ -1,5 +1,4 @@
 class Spree::Slide < ActiveRecord::Base
-
   has_and_belongs_to_many :slide_locations,
                           class_name: 'Spree::SlideLocation',
                           join_table: 'spree_slide_slide_locations'
@@ -8,12 +7,20 @@ class Spree::Slide < ActiveRecord::Base
                     url: '/spree/slides/:id/:style/:basename.:extension',
                     path: ':rails_root/public/spree/slides/:id/:style/:basename.:extension',
                     convert_options: { all: '-strip -auto-orient -colorspace sRGB' }
-  validates_attachment :image, content_type: { content_type: ["image/jpg", "image/jpeg", "image/png", "image/gif"] }
+  validates_attachment :image, content_type: { content_type: ['image/jpg', 'image/jpeg', 'image/png', 'image/gif'] }
 
   scope :published, -> { where(published: true).order('position ASC') }
-  scope :location, -> (location) { joins(:slide_locations).where('spree_slide_locations.name = ?', location) }
+  scope :location, ->(location) { joins(:slide_locations).where('spree_slide_locations.name = ?', location) }
 
   belongs_to :product, touch: true
+
+  def self.in_time
+    where '(starts_at is NULL AND ends_at is NULL)
+           OR (starts_at <= ? AND ends_at is NULL)
+           OR (starts_at is NULL AND ends_at >= ?)
+           OR (starts_at <= ? AND ends_at >= ?)',
+          *([Time.now] * 4)
+  end
 
   def initialize(attrs = nil)
     attrs ||= { published: true }
@@ -30,5 +37,9 @@ class Spree::Slide < ActiveRecord::Base
 
   def slide_image
     !image.file? && product.present? && product.images.any? ? product.images.first.attachment : image
+  end
+
+  def in_time?
+    Time.now.between?(starts_at || 1.second.ago, ends_at || 1.second.from_now)
   end
 end

--- a/app/views/spree/admin/slides/_form.html.erb
+++ b/app/views/spree/admin/slides/_form.html.erb
@@ -37,6 +37,22 @@
   </div>
 
   <div class="col-md-6">
+    <%= f.field_container :starts_at do %>
+        <%= f.label :starts_at, 'Starts at' %><br>
+        <div class="help-block">The slide will not be shown before this date, even if published</div>
+        <%= f.date_field :starts_at, 'Starts at' %><br>
+    <% end %>
+  </div>
+
+  <div class="col-md-6">
+    <%= f.field_container :ends_at do %>
+        <%= f.label :ends_at, 'Ends at' %><br>
+        <div class="help-block">The slide will not be shown after this date, even if published</div>
+        <%= f.date_field :ends_at, 'Ends at' %><br>
+    <% end %>
+  </div>
+
+  <div class="col-md-6">
     <%= render 'spree/admin/slides/edit_slider_locations', f: f %>
   </div>
 

--- a/db/migrate/20170906023647_add_starts_at_and_ends_at_columns_to_spree_slides.rb
+++ b/db/migrate/20170906023647_add_starts_at_and_ends_at_columns_to_spree_slides.rb
@@ -1,0 +1,6 @@
+class AddStartsAtAndEndsAtColumnsToSpreeSlides < ActiveRecord::Migration
+  def change
+    add_column :spree_slides, :starts_at, :datetime
+    add_column :spree_slides, :ends_at, :datetime
+  end
+end

--- a/spec/models/spree/slide_decorator_spec.rb
+++ b/spec/models/spree/slide_decorator_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Slide do
+  describe '#in_time?' do
+    context 'when both starts_at and ends_at are nil' do
+      subject { Spree::Slide.new starts_at: nil, ends_at: nil }
+
+      it { is_expected.to be_in_time }
+    end
+
+    context 'when starts_at is in the past and ends_at is nil' do
+      subject { Spree::Slide.new starts_at: 2.days.ago, ends_at: nil }
+
+      it { is_expected.to be_in_time }
+    end
+
+    context 'when starts_at is in the future and ends_at is nil' do
+      subject { Spree::Slide.new starts_at: 2.days.from_now, ends_at: nil }
+
+      it { is_expected.not_to be_in_time }
+    end
+
+    context 'when starts_at is nil and ends_at is in the future' do
+      subject { Spree::Slide.new starts_at: nil, ends_at: 2.days.from_now }
+
+      it { is_expected.to be_in_time }
+    end
+
+    context 'when starts_at is nil and ends_at is in the past' do
+      subject { Spree::Slide.new starts_at: nil, ends_at: 2.days.ago }
+
+      it { is_expected.not_to be_in_time }
+    end
+
+    context 'when both starts_at and end_at is in the past' do
+      subject { Spree::Slide.new starts_at: 2.days.ago, ends_at: 1.day.ago }
+
+      it { is_expected.not_to be_in_time }
+    end
+
+    context 'when starts_at is in the past and end_at is in the future' do
+      subject { Spree::Slide.new starts_at: 2.days.ago, ends_at: 2.days.from_now }
+
+      it { is_expected.to be_in_time }
+    end
+  end
+
+  describe '.in_time' do
+    it 'returns all the slides from the database that are in time' do
+      good_slides = [
+        Spree::Slide.create(starts_at: nil, ends_at: nil),
+        Spree::Slide.create(starts_at: 2.days.ago, ends_at: nil),
+        Spree::Slide.create(starts_at: nil, ends_at: 2.days.from_now),
+        Spree::Slide.create(starts_at: 2.days.ago, ends_at: 2.days.from_now)
+      ].map(&:id)
+
+      bad_slides = [
+        Spree::Slide.create(starts_at: 2.days.from_now, ends_at: nil),
+        Spree::Slide.create(starts_at: nil, ends_at: 2.days.ago),
+        Spree::Slide.create(starts_at: 2.days.ago, ends_at: 1.day.ago)
+      ].map(&:id)
+
+      slides = Spree::Slide.in_time.map(&:id)
+      expect(slides).to include *good_slides
+      expect(slides).not_to include *bad_slides
+    end
+  end
+end


### PR DESCRIPTION
This makes possible to control slides publication using timestamps. This adds three new behaviors:

1. Slides where both `starts_at` and `ends_at` are defined are only shown if they are published and `Time.now` is between `starts_at` and `ends_at`.
1. Slides that have only `starts_at` defined will be be shown only if they are published and `starts_at` is in the past.
3. Slides where `starts_at` and `ends_at` are `nil` and  are always shown if they are published.

Also, this adds fields to capture `starts_at` and `ends_at` for each slide in the admin UI.